### PR TITLE
QQ登录添加 sub和gender claim

### DIFF
--- a/src/Microsoft.AspNetCore.Authentication.QQ/QQOptions.cs
+++ b/src/Microsoft.AspNetCore.Authentication.QQ/QQOptions.cs
@@ -20,6 +20,8 @@ namespace Microsoft.AspNetCore.Authentication.QQ
 
             ClaimActions.MapJsonKey(ClaimTypes.NameIdentifier, "openid");
             ClaimActions.MapJsonKey(ClaimTypes.Name, "nickname");
+            ClaimActions.MapJsonKey(ClaimTypes.Gender, "gender");
+            ClaimActions.MapJsonKey("sub", "openid");
             ClaimActions.MapJsonKey("urn:qq:figure", "figureurl_qq_1");
         }
 


### PR DESCRIPTION
1.添加gender的原因是因为这个属性比较常用，而且QQ也是返回了的。
2.添加sub claim是因为IdentityServer4在使用这个外部认证组件时校验了sub claim，如果没有会报错。如果加上这个本组件也能用于IdentityServer4
